### PR TITLE
Remove django from `install_requires`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     zip_safe=False,
     author='Marco Braak',
     author_email='mbraak@ridethepony.nl',
-    install_requires=['django', 'docopt'],
+    install_requires=['docopt'],
     description='Django-docopt-command allows you to write Django manage.py commands using the docopt library',
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Having `django` in `install_requires` makes it impossible to try out a Django release candidate or dev branch. My requirements file is something like this:

```
https://www.djangoproject.com/download/1.7c1/tarball/
django-docopt-command==0.1.0
```

But when I `pip install -r requirements.txt` it first installs Django 1.7c1, then `django-docopt-command` tries to being in Django 1.6.5:

```
Downloading/unpacking django (from django-docopt-command==0.1.0->-r requirements/_common.txt (line 8))
```

This unfortunately trashes my existing Django install: I see this output at some point:

```
    You have just installed Django over top of an existing
    installation, without removing it first. Because of this,
    your install may now include extraneous files from a
    previous version that have since been removed from
    Django. This is known to cause a variety of problems. You
    should manually remove the

    /home/paul/.virtualenvs/api3/lib/python2.7/site-packages/django

    directory and re-install Django.
```

For reference, other Django packages don't specify a requirement on Django for installation, and I think this is the correct thing to do:
- https://github.com/tomchristie/django-rest-framework/blob/master/setup.py
- https://github.com/kennethreitz/dj-static/blob/master/setup.py
