### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/django_docopt_command/command.py
+++ b/django_docopt_command/command.py
@@ -42,7 +42,7 @@ class DocOptCommand(BaseCommand):
             if arguments.get('--traceback', False):
                 stderr.write(traceback.format_exc())
             else:
-                stderr.write('%s: %s' % (e.__class__.__name__, e))
+                stderr.write('{0!s}: {1!s}'.format(e.__class__.__name__, e))
             sys.exit(1)
 
     def _handle_default_options(self, arguments):

--- a/testproject/docopt_example/management/commands/naval_fate.py
+++ b/testproject/docopt_example/management/commands/naval_fate.py
@@ -28,7 +28,7 @@ class Command(DocOptCommand):
         if arguments.get('new') and arguments.get('ship'):
             ships = arguments['<name>']
 
-            print('new ship: %s' % ', '.join(ships))
+            print('new ship: {0!s}'.format(', '.join(ships)))
         elif arguments.get('ship') and arguments.get('move'):
             ship = arguments['<name>'][0]
             x = arguments['<x>']
@@ -36,21 +36,21 @@ class Command(DocOptCommand):
             speed = arguments['--speed']
 
             if speed:
-                print('move ship %s to %s %s with speed %s' % (ship, x, y, speed))
+                print('move ship {0!s} to {1!s} {2!s} with speed {3!s}'.format(ship, x, y, speed))
             else:
-                print('move ship %s to %s %s' % (ship, x, y))
+                print('move ship {0!s} to {1!s} {2!s}'.format(ship, x, y))
         elif arguments.get('ship') and arguments.get('shoot'):
             x = arguments['<x>']
             y = arguments['<y>']
 
-            print('shoot ship %s %s' % (x, y))
+            print('shoot ship {0!s} {1!s}'.format(x, y))
         elif arguments.get('mine') and arguments.get('set'):
             x = arguments['<x>']
             y = arguments['<y>']
             moored = arguments.get('--moored')
             drifting = arguments.get('--drifting')
 
-            print('set mine at position %s %s' % (x, y))
+            print('set mine at position {0!s} {1!s}'.format(x, y))
 
             if moored:
                 print('moored')
@@ -62,7 +62,7 @@ class Command(DocOptCommand):
             moored = arguments.get('--moored')
             drifting = arguments.get('--drifting')
 
-            print('remove mine at position %s %s' % (x, y))
+            print('remove mine at position {0!s} {1!s}'.format(x, y))
 
             if moored:
                 print('moored')


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:mbraak:django-docopt-command?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:mbraak:django-docopt-command?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)